### PR TITLE
Add monitoring start segment method

### DIFF
--- a/monitoring/instruments_test.go
+++ b/monitoring/instruments_test.go
@@ -1,1 +1,30 @@
 package monitoring
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStartSegment_NoCurSpan(t *testing.T) {
+	_, end := StartSegment(context.Background(), "test")
+	end()
+}
+
+func TestStartSegment_WithCurSpan(t *testing.T) {
+	ctx, _ := tracer.Start(context.Background(), "parent_span")
+
+	_, end := StartSegment(ctx, "test")
+	end()
+}
+
+func TestStartSegmentWithTags_NoCurSpan(t *testing.T) {
+	_, end := StartSegmentWithTags(context.Background(), "test", map[string]string{"key": "value"})
+	end()
+}
+
+func TestStartSegmentWithTags_WithCurSpan(t *testing.T) {
+	ctx, _ := tracer.Start(context.Background(), "parent_span")
+
+	_, end := StartSegmentWithTags(ctx, "test", map[string]string{"key": "value"})
+	end()
+}

--- a/monitoring/tracer.go
+++ b/monitoring/tracer.go
@@ -1,0 +1,15 @@
+package monitoring
+
+import (
+	"go.opentelemetry.io/otel"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	tracerName = "github.com/viebiz/lit/monitoring"
+)
+
+var (
+	tracer = otel.Tracer(tracerName, trace.WithSchemaURL(semconv.SchemaURL))
+)


### PR DESCRIPTION
# Description

```
func doSomething(ctx context.Context, input string) {
	ctx, end := monitoring.StartSegment(ctx, "doSomething", map[string]string{
		"input", input,
	})
	defer end()

	// Business logic stuff
}
```