### PR TITLE
Update redis subcriber feature

### DIFF
--- a/caching/redis/pubsub_option.go
+++ b/caching/redis/pubsub_option.go
@@ -1,0 +1,27 @@
+package redis
+
+import (
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type ChannelOption struct {
+	ChannelSize         int
+	HealthCheckInterval time.Duration
+	SendTimeout         time.Duration
+}
+
+func (opt ChannelOption) toRedisOptions() []redis.ChannelOption {
+	opts := make([]redis.ChannelOption, 0, 3)
+	if opt.ChannelSize > 0 {
+		opts = append(opts, redis.WithChannelSize(opt.ChannelSize))
+	}
+	if opt.HealthCheckInterval > 0 {
+		opts = append(opts, redis.WithChannelHealthCheckInterval(opt.HealthCheckInterval))
+	}
+	if opt.SendTimeout > 0 {
+		opts = append(opts, redis.WithChannelSendTimeout(opt.SendTimeout))
+	}
+	return opts
+}


### PR DESCRIPTION
# Description

Add SubscribeWithOptions for Redis subscriber
Introduces SubscribeWithOptions using PubSub.Channel()
Adds default channel options (buffer, health check, send timeout)
Supports custom ChannelOption overrides
Implements retry & resubscribe with backoff for transient errors
Stops cleanly on context cancellation or fatal errors