### PR TITLE
Update default env file name and unit test

### DIFF
--- a/env/apis.go
+++ b/env/apis.go
@@ -10,7 +10,7 @@ import (
 const (
 	defaultConfigPath  = "."
 	defaultFormat      = "env"
-	defaultEnvFilename = "config.env"
+	defaultEnvFilename = ".env"
 	envVarPrefix       = "app"
 )
 

--- a/env/apis_test.go
+++ b/env/apis_test.go
@@ -121,6 +121,9 @@ func TestReadAppConfig(t *testing.T) {
 }
 
 func TestReadAppConfig_UnmarshalError(t *testing.T) {
+	end := setupDefaultENV(t)
+	defer end()
+
 	// Given
 	type config struct {
 		AppName chan int `mapstructure:"APP_NAME"` // A channel can't be unmarshaled, forcing an error
@@ -132,4 +135,18 @@ func TestReadAppConfig_UnmarshalError(t *testing.T) {
 	// Then
 	require.Zero(t, cfg)
 	require.ErrorContains(t, err, "unmarshal to object error")
+}
+
+func setupDefaultENV(t *testing.T) func() {
+	envFile, err := os.Create(".env")
+	require.NoError(t, err)
+
+	_, err = envFile.WriteString(`APP_NAME=lightning\nLANG=en,vi\nDB.URL=postgres:thisisurl\nWEB.HOST=0.0.0.0\nWEB.PORT=8080\n`)
+	require.NoError(t, err)
+	require.NoError(t, envFile.Sync())
+
+	return func() {
+		require.NoError(t, envFile.Close())
+		require.NoError(t, os.Remove(envFile.Name()))
+	}
 }

--- a/env/config.env
+++ b/env/config.env
@@ -1,7 +1,0 @@
-APP_NAME=lightning
-LANG=en,vi
-
-DB.URL=postgres:thisisurl
-
-WEB.HOST=0.0.0.0
-WEB.PORT=8080


### PR DESCRIPTION
# Description

Allow to read config from `.env` by default