### PR TITLE
Update redis pubsub command and error handling for setSingleValue

### DIFF
--- a/caching/redis/function.go
+++ b/caching/redis/function.go
@@ -30,6 +30,10 @@ func setSingleValue[T Type](
 	// 2. Set value to redis
 	status, err := rdb.SetArgs(ctx, key, value, args).Result()
 	if err != nil {
+		if mode == setModeNX && errors.Is(err, redis.Nil) {
+			return ErrFailToSetValue
+		}
+
 		return pkgerrors.WithStack(err)
 	}
 

--- a/caching/redis/pubsub.go
+++ b/caching/redis/pubsub.go
@@ -14,8 +14,7 @@ import (
 
 // Publish posts a new message to server
 func (client redisClient) Publish(ctx context.Context, channel string, payload any) error {
-	// Use SPUBLISH for better efficiency with sharding (Redis Cluster), If not using sharding it the same PUBLISH
-	return client.rdb.SPublish(ctx, channel, payload).Err()
+	return client.rdb.Publish(ctx, channel, payload).Err()
 }
 
 func (client redisClient) Subscribe(ctx context.Context, channels []string, handler MessageHandler) Subscriber {
@@ -32,7 +31,7 @@ func (client redisClient) Subscribe(ctx context.Context, channels []string, hand
 		handler:  handler,
 		monitor:  monitor,
 		subscribeFunc: func(ctx context.Context, channels ...string) RedisPubSub {
-			return client.rdb.SSubscribe(ctx, channels...)
+			return client.rdb.Subscribe(ctx, channels...)
 		},
 	}
 }

--- a/caching/redis/pubsub_test.go
+++ b/caching/redis/pubsub_test.go
@@ -73,7 +73,7 @@ func TestRedisClient_Publish(t *testing.T) {
 			tc.givenMockCmdArg = tc.givenMockCmdArgFn()
 			mockUniversalClient.ExpectedCalls = []*mock.Call{
 				mockUniversalClient.On(
-					"SPublish",
+					"Publish",
 					tc.givenMockCmdArg.givenContext,
 					tc.givenMockCmdArg.givenChannel,
 					tc.givenMockCmdArg.givenValue,


### PR DESCRIPTION
# Description

- Change redis pubsub command, using `PUBLISH`, `SUBSCRIBE` instead of `SPUBLISH`, `SSUBSCRIBE`.
- Return `ErrFailToSetValue` when got error `redis.Nil` when SET key NX.